### PR TITLE
Add ability to override cancel button class

### DIFF
--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -17,6 +17,7 @@
         confirmButtonText: 'OK',
         confirmButtonClass: 'btn-primary',
         cancelButtonText: 'Cancel',
+        cancelButtonClass: 'btn-default',
         imageUrl: null,
         imageSize: null,
         timer: null
@@ -176,7 +177,7 @@
    */
 
   window.sweetAlertInitialize = function() {
-    var sweetHTML = '<div class="sweet-overlay" tabIndex="-1"></div><div class="sweet-alert" tabIndex="-1"><div class="icon error"><span class="x-mark"><span class="line left"></span><span class="line right"></span></span></div><div class="icon warning"> <span class="body"></span> <span class="dot"></span> </div> <div class="icon info"></div> <div class="icon success"> <span class="line tip"></span> <span class="line long"></span> <div class="placeholder"></div> <div class="fix"></div> </div> <div class="icon custom"></div> <h2>Title</h2><p class="lead text-muted">Text</p><p><button class="cancel btn btn-default btn-lg" tabIndex="2">Cancel</button> <button class="confirm btn btn-lg" tabIndex="1">OK</button></p></div>',
+    var sweetHTML = '<div class="sweet-overlay" tabIndex="-1"></div><div class="sweet-alert" tabIndex="-1"><div class="icon error"><span class="x-mark"><span class="line left"></span><span class="line right"></span></span></div><div class="icon warning"> <span class="body"></span> <span class="dot"></span> </div> <div class="icon info"></div> <div class="icon success"> <span class="line tip"></span> <span class="line long"></span> <div class="placeholder"></div> <div class="fix"></div> </div> <div class="icon custom"></div> <h2>Title</h2><p class="lead text-muted">Text</p><p><button class="cancel btn btn-lg" tabIndex="2">Cancel</button> <button class="confirm btn btn-lg" tabIndex="1">OK</button></p></div>',
         sweetWrap = document.createElement('div');
 
     sweetWrap.innerHTML = sweetHTML;
@@ -235,6 +236,7 @@
         params.confirmButtonText  = arguments[0].confirmButtonText || defaultParams.confirmButtonText;
         params.confirmButtonClass = arguments[0].confirmButtonClass || defaultParams.confirmButtonClass;
         params.cancelButtonText   = arguments[0].cancelButtonText || defaultParams.cancelButtonText;
+        params.cancelButtonClass  = arguments[0].cancelButtonClass || defaultParams.cancelButtonClass;
         params.imageUrl           = arguments[0].imageUrl || defaultParams.imageUrl;
         params.imageSize          = arguments[0].imageSize || defaultParams.imageSize;
         params.doneFunction       = arguments[1] || null;
@@ -548,6 +550,9 @@
 
     // Set confirm button to selected class
     addClass($confirmBtn, params.confirmButtonClass);
+
+    // Set cancel button to selected class
+    addClass($cancelBtn, params.cancelButtonClass);
 
     // Allow outside click?
     modal.setAttribute('data-allow-ouside-click', params.allowOutsideClick);


### PR DESCRIPTION
Allows the caller to define a custom CSS class for the Cancel button and preserves the existing default class (`btn-default`).
