### PR TITLE
Allow custom classes to be attached to the sweetalert modal, title, and message.

### DIFF
--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -18,6 +18,9 @@
         confirmButtonClass: 'btn-primary',
         cancelButtonText: 'Cancel',
         cancelButtonClass: 'btn-default',
+        containerClass: '',
+        titleClass: '',
+        textClass: '',
         imageUrl: null,
         imageSize: null,
         timer: null
@@ -38,7 +41,7 @@
       return new RegExp(' ' + className + ' ').test(' ' + elem.className + ' ');
     },
     addClass = function(elem, className) {
-      if (!hasClass(elem, className)) {
+      if (className && !hasClass(elem, className)) {
         elem.className += ' ' + className;
       }
     },
@@ -237,6 +240,9 @@
         params.confirmButtonClass = arguments[0].confirmButtonClass || defaultParams.confirmButtonClass;
         params.cancelButtonText   = arguments[0].cancelButtonText || defaultParams.cancelButtonText;
         params.cancelButtonClass  = arguments[0].cancelButtonClass || defaultParams.cancelButtonClass;
+        params.containerClass     = arguments[0].containerClass || defaultParams.containerClass;
+        params.titleClass         = arguments[0].titleClass || defaultParams.titleClass;
+        params.textClass          = arguments[0].textClass || defaultParams.textClass;
         params.imageUrl           = arguments[0].imageUrl || defaultParams.imageUrl;
         params.imageSize          = arguments[0].imageSize || defaultParams.imageSize;
         params.doneFunction       = arguments[1] || null;
@@ -548,11 +554,20 @@
     // Reset confirm buttons to default class (Ugly fix)
     $confirmBtn.className = 'confirm btn btn-lg'
 
+    // Attach selected class to the sweet alert modal
+    addClass(modal, params.containerClass);
+
     // Set confirm button to selected class
     addClass($confirmBtn, params.confirmButtonClass);
 
     // Set cancel button to selected class
     addClass($cancelBtn, params.cancelButtonClass);
+
+    // Set title to selected class
+    addClass($title, params.titleClass);
+
+    // Set text to selected class
+    addClass($text, params.textClass);
 
     // Allow outside click?
     modal.setAttribute('data-allow-ouside-click', params.allowOutsideClick);


### PR DESCRIPTION
This allows the caller to attach a custom, supplementary class to the `.sweet-alert` modal, the title `h2` of the modal, and the message `p`. It also updates the `addClass` function to ignore any attempts to add falsy class names.