### PR TITLE
Adding option to hide the confirm button

### DIFF
--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -12,6 +12,7 @@
         type: null,
         allowOutsideClick: false,
         showCancelButton: false,
+        showConfirmButton: true,
         closeOnConfirm: true,
         closeOnCancel: true,
         confirmButtonText: 'OK',
@@ -230,6 +231,7 @@
         params.type               = arguments[0].type || defaultParams.type;
         params.allowOutsideClick  = arguments[0].allowOutsideClick || defaultParams.allowOutsideClick;
         params.showCancelButton   = arguments[0].showCancelButton !== undefined ? arguments[0].showCancelButton : defaultParams.showCancelButton;
+        params.showConfirmButton  = arguments[0].showConfirmButton !== undefined ? arguments[0].showConfirmButton : defaultParams.showConfirmButton;
         params.closeOnConfirm     = arguments[0].closeOnConfirm !== undefined ? arguments[0].closeOnConfirm : defaultParams.closeOnConfirm;
         params.closeOnCancel      = arguments[0].closeOnCancel !== undefined ? arguments[0].closeOnCancel : defaultParams.closeOnCancel;
         params.timer              = arguments[0].timer || defaultParams.timer;
@@ -542,6 +544,15 @@
     } else {
       hide($cancelBtn);
     }
+    
+    //Confirm button
+    modal.setAttribute('data-has-confirm-button', params.showConfirmButton);
+    if (params.showConfirmButton) {
+      $confirmBtn.style.display = 'inline-block';
+    } else {
+      hide($confirmBtn);
+    }
+    
 
     // Edit text on cancel and confirm buttons
     if (params.cancelButtonText) {
@@ -552,7 +563,7 @@
     }
 
     // Reset confirm buttons to default class (Ugly fix)
-    $confirmBtn.className = 'confirm btn btn-lg'
+    $confirmBtn.className = 'confirm btn btn-lg';
 
     // Attach selected class to the sweet alert modal
     addClass(modal, params.containerClass);


### PR DESCRIPTION
 Added the option to not show the confirm buttons (defaults to show, of course). This is to set up a "loading" or "processing" alert so the user should wait. 

Also added a semicolon that was missing.

Example: post something to the server and make the user wait for it to finish then redirect (if success) or close the alert(if fails).