### PR TITLE
add word-break for text to avoid text-overflow

### DIFF
--- a/lib/sweet-alert.css
+++ b/lib/sweet-alert.css
@@ -562,3 +562,7 @@
 .sweet-alert button::-moz-focus-inner {
   border: 0;
 }
+
+.sweet-alert .lead.text-muted{
+  word-break:break-all;
+}


### PR DESCRIPTION
if we tip text like below
"No dimension columns defined for Table[DEFAULT.TEST_TABLE_FOR_TEST_ONLY_ONLY]"
we can see text overflow.
so add this style can avoid.
