### PR TITLE
 Set the confirmButtonClass from the type of sweet alert

### DIFF
--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -214,9 +214,10 @@
     switch (typeof arguments[0]) {
 
       case 'string':
-        params.title = arguments[0];
-        params.text  = arguments[1] || '';
-        params.type  = arguments[2] || '';
+        params.title              = arguments[0];
+        params.text               = arguments[1] || '';
+        params.type               = arguments[2] || '';
+        params.confirmButtonClass = params.type ? 'btn-' + params.type : defaultParams.confirmButtonClass;
 
         break;
 


### PR DESCRIPTION
Set the `confirmButtonClass` from the type of sweet alert that is passed in as a string argument

Ref:
https://github.com/lipis/bootstrap-sweetalert/commit/3d775795c4e99b6797a61f67b94d429303266529

Extended the above so that the `confirmButtonClass` also matches the type when the shorthand parameters option is used.

`confirmButtonClass` is the only one under the object based parameters that can optionally set itself from one of the three primary parameters (title, text, type), so it made sense at least to me to infer it when passing in strings to `swal()` instead of a parameter object.