### PR TITLE
Hide success animation background from view

### DIFF
--- a/lib/sweet-alert.less
+++ b/lib/sweet-alert.less
@@ -142,7 +142,7 @@
         position: absolute;
         width: 60px;
         height: 120px;
-        background: white;
+        background: @body-bg;
         -webkit-transform: rotate(45deg);
                 transform: rotate(45deg);
       }


### PR DESCRIPTION
Fixes #34. 

Similar to the rule for [.fix](https://github.com/lipis/bootstrap-sweetalert/blob/master/lib/sweet-alert.less#L183), the animation *background* should match @body-bg so that it's not visible.